### PR TITLE
Remove dependency on capistrano-releaseboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This gem makes the following assumptions about your Ruby project
 - You do not have an .rvmrc checked into git (should be in your .gitignore)
 - You will not use rvm gemsets on the server you deploy to
 - Bundler will install specified gems into {your_project_home}/shared/bundle directory
-- You have a VERSION file that contains an x.y.z version number. This will get passed to the DLSS release board
 - Will deploy from the master branch, unless you set :branch to another branch or tag
 
 

--- a/dlss-capistrano.gemspec
+++ b/dlss-capistrano.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   # All dependencies are runtime dependencies, since this gem's "runtime" is
   # the dependent gem's development-time.
   s.add_dependency "capistrano", "~> 3.0"
-  s.add_dependency "capistrano-releaseboard"
   s.add_dependency "capistrano-bundle_audit", ">= 0.1.0"
   s.add_dependency "capistrano-one_time_key"
   s.add_dependency "capistrano-shared_configs"

--- a/lib/dlss/capistrano.rb
+++ b/lib/dlss/capistrano.rb
@@ -1,6 +1,3 @@
-ENV['RELEASE_BOARD_URL'] ||= "https://dlss-releases.stanford.edu"
-
 require 'capistrano/one_time_key'
-require 'capistrano/releaseboard'
 require 'capistrano/bundle_audit'
 require 'capistrano/shared_configs'


### PR DESCRIPTION
I wasn't sure whether there's any reason to keep the VERSION file apart from the releaseboard needing it. I'm happy to remove that assumption from the README if there isn't.