### PR TITLE
Add a task to print out what commit (and the branch(es) containing the commit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Set this in `config/deploy.rb` to automate the symlink creation, and then use `X
 
 `cap ENV ssh` establishes an SSH connection to the host running in `ENV` environment, and changes into the current deployment directory
 
+### Display Revision (and branches)
+
+`cap ENV deployed_branch` displays the currently deployed revision (commit ID) and any branches containing the revision for each server in `ENV`.
+
 ### Sidekiq via systemd
 
 `cap ENV sidekiq_systemd:{quiet,stop,start,restart}`: quiets, stops, starts, restarts Sidekiq via systemd.

--- a/lib/dlss/capistrano/tasks/deployed_branch.rake
+++ b/lib/dlss/capistrano/tasks/deployed_branch.rake
@@ -1,0 +1,10 @@
+desc 'display the deployed branch and commit'
+task :deployed_branch do
+  on roles(:app) do |host|
+    within current_path do
+      revision = capture :cat, 'REVISION'
+      branches = `git branch -r --contains #{revision}`.strip
+      info "#{host}: #{revision} (#{branches})"
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This makes it easy to figure out what is deployed without having to SSH to the server

## How was this change tested?

Ran it in Argo.

## Which documentation and/or configurations were updated?

README

