### PR TITLE
Add an ssh_check task to verify SSH connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Set this in `config/deploy.rb` to automate the symlink creation, and then use `X
 
 `cap ENV ssh` establishes an SSH connection to the host running in `ENV` environment, and changes into the current deployment directory
 
+### SSH Connection Checking
+
+`cap ENV ssh_check` establishes an SSH connection to all app servers running in `ENV` environment and prints environment information to confirm the connection was made. This is used by [sdr-deploy](https://github.com/sul-dlss-labs/sdr-deploy/) to check SSH connections can be made in bulk before proceeding with a mass deploy.
+
 ### Display Revision (and branches)
 
 `cap ENV deployed_branch` displays the currently deployed revision (commit ID) and any branches containing the revision for each server in `ENV`.

--- a/lib/dlss/capistrano/tasks/ssh_check.rake
+++ b/lib/dlss/capistrano/tasks/ssh_check.rake
@@ -1,0 +1,6 @@
+desc "check ssh connections to all app servers"
+task :ssh_check do
+  on roles(:app), in: :sequence do
+    execute
+  end
+end


### PR DESCRIPTION
## Why was this change made?

`cap ENV ssh_check` establishes an SSH connection to all app servers running in `ENV` environment and prints uptime information to confirm the connection was made. This is used by [sdr-deploy](https://github.com/sul-dlss-labs/sdr-deploy/) to check SSH connections can be made in bulk before proceeding with a mass deploy.

## How was this change tested?

Manually

## Which documentation and/or configurations were updated?

README

