### PR TITLE
Add optional resque-pool management tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ Set this in `config/deploy.rb` to automate the symlink creation, and then use `X
 
 `cap ENV deployed_branch` displays the currently deployed revision (commit ID) and any branches containing the revision for each server in `ENV`.
 
+### Resque-Pool hot swap (OPTIONAL)
+
+The `dlss-capistrano` gem provides a set of tasks for managing `resque-pool` workers when deployed in `hot_swap` mode. (If you are using `resque-pool` without `hot_swap`, we recommend continuing to use the `capistrano-resque-pool` gem instead of what `dlss-capistrano` provides.) The tasks are:
+
+```shell
+$ cap ENV resque:pool:hot_swap # this gracefully replaces the current pool with a new pool
+$ cap ENV resque:pool:stop     # this gracefully stops the current pool
+```
+
+By default, these tasks are not provided; instead, they must be explicitly enabled via adding a new `require` statement to the application's `Capfile`:
+
+```ruby
+require 'dlss/capistrano/resque_pool'
+```
+
 ### Sidekiq via systemd
 
 `cap ENV sidekiq_systemd:{quiet,stop,start,restart}`: quiets, stops, starts, restarts Sidekiq via systemd.

--- a/lib/dlss/capistrano/resque_pool.rb
+++ b/lib/dlss/capistrano/resque_pool.rb
@@ -1,0 +1,1 @@
+import "#{__dir__}/resque_pool/tasks/resque_pool.rake"

--- a/lib/dlss/capistrano/resque_pool/tasks/resque_pool.rake
+++ b/lib/dlss/capistrano/resque_pool/tasks/resque_pool.rake
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# These tasks are a drop-in replacement for capistrano-resque-pool when using
+# hot-swappable pools. We replace these tasks because the upstream ones assume a
+# pidfile is present, which is not the case with hot-swappable pools.
+
+namespace :load do
+  task :defaults do
+    # Same capistrano variable used by capistrano-resque-pool for compatibility
+    set :resque_server_roles, fetch(:resque_server_roles, [:app])
+  end
+end
+
+# Integrate hook into Capistrano
+namespace :deploy do
+  before :starting, :add_resque_pool_hotswap_hook do
+    invoke 'resque:pool:add_hook'
+  end
+end
+
+namespace :resque do
+  namespace :pool do
+    # Lifted from capistrano-resque-pool
+    def rails_env
+      fetch(:resque_rails_env) ||
+        fetch(:rails_env) ||       # capistrano-rails doesn't automatically set this (yet),
+        fetch(:stage)              # so we need to fall back to the stage.
+    end
+
+    # NOTE: no `desc` here to avoid publishing this task in the `cap -T` list
+    task :add_hook do
+      after 'deploy:restart', 'resque:pool:hot_swap'
+    end
+
+    desc 'Swap in a new pool, then shut down the old pool'
+    task :hot_swap do
+      on roles(fetch(:resque_server_roles)) do
+        within current_path do
+          execute :bundle, :exec, 'resque-pool', "--daemon --hot-swap --environment #{rails_env}"
+        end
+      end
+    end
+
+    desc 'Gracefully shut down current pool'
+    task :stop do
+      on roles(fetch(:resque_server_roles)) do
+        # This will usually return a single pid, but if you do multiple quick
+        # deployments, you may pick up multiple pids here, in which case we only
+        # kill the oldest one
+        pid = capture(:pgrep, '-f resque-pool-master').split.first
+
+        if test "kill -0 #{pid} > /dev/null 2>&1"
+          execute :kill, "-s QUIT #{pid}"
+        else
+          warn "Process #{pid} is not running"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See README for a more detailed description. Note that these tasks are not auto-loaded and must be opted into. This has been tested in the preservation_catalog codebase and run successfully in prescat QA environment.
