### PR TITLE
Fix bug in resque-pool hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ By default, these tasks are not provided; instead, they must be explicitly enabl
 require 'dlss/capistrano/resque_pool'
 ```
 
+This is the hook provided if you opt in:
+
+```ruby
+after 'deploy:publishing', 'resque:pool:hot_swap'
+```
+
 ### Sidekiq via systemd
 
 `cap ENV sidekiq_systemd:{quiet,stop,start,restart}`: quiets, stops, starts, restarts Sidekiq via systemd.

--- a/lib/dlss/capistrano/resque_pool/tasks/resque_pool.rake
+++ b/lib/dlss/capistrano/resque_pool/tasks/resque_pool.rake
@@ -29,7 +29,7 @@ namespace :resque do
 
     # NOTE: no `desc` here to avoid publishing this task in the `cap -T` list
     task :add_hook do
-      after 'deploy:restart', 'resque:pool:hot_swap'
+      after 'deploy:publishing', 'resque:pool:hot_swap'
     end
 
     desc 'Swap in a new pool, then shut down the old pool'


### PR DESCRIPTION
It turns out the deploy:restart hook is NOT a common hook. It works for Rails apps but not in other contexts. Instead, use the Capistrano built-in flow hook for `after:publishing` which occurs immediately prior to a restart which is A-OK for our purposes.
