### PR TITLE
Add tasks for starting sneakers with systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ after 'deploy:publishing', 'resque:pool:hot_swap'
 
 These tasks are intended to replace those provided by `capistrano-sidekiq` gem, which has assumptions about systemd that do not apply to our deployed environments.
 
+### Sneakers via systemd
+
+`cap ENV sneakers_systemd:{quiet,stop,start,restart}`: quiets, stops, starts, restarts Sneakers via systemd.
+
+
 #### Capistrano role
 
 The sidekiq_systemd tasks assume a Capistrano role of `:app`. If your application uses a different Capistrano role for hosts that run Sidekiq workers, you can configure this in `config/deploy.rb`, *e.g.*:

--- a/lib/dlss/capistrano/tasks/sneakers_systemd.rake
+++ b/lib/dlss/capistrano/tasks/sneakers_systemd.rake
@@ -1,0 +1,52 @@
+# Capistrano plugin hook to set default values
+namespace :load do
+  task :defaults do
+    set :sneakers_systemd_role, fetch(:sneakers_systemd_role, :app)
+    set :sneakers_systemd_use_hooks, fetch(:sneakers_systemd_use_hooks, false)
+  end
+end
+
+# Integrate sneakers hooks into Capistrano
+namespace :deploy do
+  before :starting, :add_sneakers_systemd_hooks do
+    invoke 'sneakers_systemd:add_hooks' if fetch(:sneakers_systemd_use_hooks)
+  end
+end
+
+namespace :sneakers_systemd do
+  # NOTE: no `desc` here to avoid publishing this task in the `cap -T` list
+  task :add_hooks do
+    after 'deploy:failed', 'sneakers_systemd:restart'
+    after 'deploy:published', 'sneakers_systemd:start'
+    after 'deploy:starting', 'sneakers_systemd:quiet'
+    after 'deploy:updated', 'sneakers_systemd:stop'
+  end
+
+  desc 'Stop workers from picking up new jobs'
+  task :quiet do
+    on roles fetch(:sneakers_systemd_role) do
+      sudo :systemctl, 'reload', 'sneakers', raise_on_non_zero_exit: false
+    end
+  end
+
+  desc 'Stop running workers gracefully'
+  task :stop do
+    on roles fetch(:sneakers_systemd_role) do
+      sudo :systemctl, 'stop', 'sneakers'
+    end
+  end
+
+  desc 'Start workers'
+  task :start do
+    on roles fetch(:sneakers_systemd_role) do
+      sudo :systemctl, 'start', 'sneakers'
+    end
+  end
+
+  desc 'Restart workers'
+  task :restart do
+    on roles fetch(:sneakers_systemd_role) do
+      sudo :systemctl, 'restart', 'sneakers', raise_on_non_zero_exit: false
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?
happy-heron (h2) uses sneakers to work jobs on a rabbtMQ queue.


## How was this change tested?



## Which documentation and/or configurations were updated?



