### PR TITLE
Add ability to check healthcheck status

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ set :bundled_sidekiq_roles, [:app] # this is the default value
 
 Set this in `config/deploy.rb` to automate the symlink creation, and then use `XSendFilePath /path/to/my/app/shared/bundled_sidekiq/web/assets` in Apache configuration (in Puppet).
 
+### Status checking
+
+Use `cap ENV check_status` to hit the (*e.g.*, [okcomputer](https://github.com/sportngin/okcomputer)-based) status endpoint of your application.
+
+By default, these checks run against all nodes with the `:web` role and hit the `/status/all` endpoint. These can be configured in `config/deploy.rb` (or `config/deploy/{ENV}.rb` if you need environment-specific variation):
+
+```ruby
+set :check_status_roles, [:my_status_check_web_role]
+set :check_status_path, '/my/status/check/endpoint'
+```
+
 ### SSH
 
 `cap ENV ssh` establishes an SSH connection to the host running in `ENV` environment, and changes into the current deployment directory

--- a/lib/dlss/capistrano/tasks/check_status.rake
+++ b/lib/dlss/capistrano/tasks/check_status.rake
@@ -1,0 +1,15 @@
+# Capistrano plugin hook to set default values
+namespace :load do
+  task :defaults do
+    set :check_status_roles, fetch(:check_status_roles, [:web])
+    set :check_status_path, fetch(:check_status_path, '/status/all')
+  end
+end
+
+desc 'Run status checks'
+task :check_status do
+  on roles fetch(:check_status_roles) do |host|
+    info "Checking status at https://#{host}#{fetch(:check_status_path)}:"
+    puts capture("curl https://#{host}#{fetch(:check_status_path)}")
+  end
+end


### PR DESCRIPTION
## Why was this change made?

This commit adds a new `check_status` task that allows checking a healthcheck endpoint, such as is provided by okcomputer.

It allows us to do on-demand status checks from the comfort of our terminal environment. For instance, you can run it after a deploy via `cap prod deploy check_status`. The advantage of running this check in your terminal via the SSH connection created by Capistrano is especially clear when deploying to hosts that you can't reach via HTTP (even if connected to VPN), e.g., workflow and suri (prod).

![Screenshot from 2022-04-06 12-19-56](https://user-images.githubusercontent.com/131982/162052474-7a0f2385-bfe7-46f3-bdd5-6e1d82444346.png)

![Screenshot from 2022-04-06 12-19-31](https://user-images.githubusercontent.com/131982/162052479-78668f0c-6374-49f1-8621-e4227bec1c1a.png)


## How was this change tested?

CI + tested in workflow-server-rails

## Which documentation and/or configurations were updated?

README
