### PR TITLE
Add ruby version reporting tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,10 +144,15 @@ The `check_app_version` task is a human readable format of the `installed_versio
 
 The `verify_deployed_version` is available to use as a deployment hook in order to halt deployment on a version mismatch
 
-Add the following to `configs/deploy/env.rb`
+By default, this task is disabled. Add the following to `configs/deploy.rb` to enable the `verify_deployed_version` task.
 
 ```
-before 'deploy:starting', 'ruby:verify_deployed_version'
+set :validate_ruby_on_deploy, true # Default value is false
+```
+
+When enabled, the validation can be manually skipped when necessary by setting the `SKIP_VALIDATE_RUBY` environment veriable:
+```
+SKIP_VALIDATE_RUBY=true bundle exec cap env deploy
 ```
 
 If there is a version mismatch, the deployment will be stopped and the following message will be reported:

--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ This comma seperated list is `hostname: default ruby,installed versions`. This l
 ```
 bundle exec cap env ruby:check_version
 => host-1.stanford.edu - App: 3.1.1, Default: 3.1.1, Installed: 2.7.1, 2.7.2, 3.0.0, 3.0.3, 3.1.0, 3.1.1, 3.1.2
+     	Passenger: Version: ruby 3.1.1p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
 => host-2.stanford.edu - App: 3.1.1, Default: 3.1.1, Installed: 2.7.1, 2.7.2, 3.0.0, 3.0.3, 3.1.0, 3.1.1, 3.1.2
+      Passenger: Version: ruby 3.1.1p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
 ```
 
 The `check_app_version` task is a human readable format of the `installed_versions` task. If the application does not default a version in the `Gemfile` then `N/A` is reported.
@@ -158,6 +160,11 @@ In the case that the application does not define a version in the `Gemfile` repo
 Ruby version not set in application, check Gemfile
 ```
 
+If the version required by the app is not reported as the version being used by Passenger, the deployment will be aborted with the following message:
+```
+Cannot deploy because app required ruby 3.1.1, Passenger is configured to use:
+    Passenger: Version: ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
+```
 ## Assumptions
 
 dlss-capistrano makes the following assumptions about your Ruby project

--- a/README.md
+++ b/README.md
@@ -114,62 +114,27 @@ after 'deploy:starting', 'sidekiq_systemd:quiet'
 after 'deploy:updated', 'sidekiq_systemd:stop'
 ```
 
+### Validate Ruby Version
 
-### Verify Ruby Versions
-
-There are three tasks available to check and verify the ruby version(s) installed and being used on the remote server:
-
-#### ruby:installed_versions
+There is a task available to make sure the Ruby version specified in the Gemfile is installed and being used on the server:
 
 ```
-bundle exec cap env ruby:versions
-=> host-1.stanford.edu: 3.1.1,2.7.1,2.7.2,3.0.0,3.0.3,3.1.0,3.1.1,3.1.2
-=> host-2.stanford.edu: 3.1.1,2.7.1,2.7.2,3.0.0,3.0.3,3.1.0,3.1.1,3.1.2
+bundle exec cap env ruby:validate_deployed_version
 ```
 
-This comma seperated list is `hostname: default ruby,installed versions`. This list can then be uesd in automated deployment tools to report across hosts where version mismatches may occur.
+If a Ruby version is not specified in the Gemfile, or if that version is not installed on the server, the task will abort.
 
-#### ruby:check_app_version
-```
-bundle exec cap env ruby:check_version
-=> host-1.stanford.edu - App: 3.1.1, Default: 3.1.1, Installed: 2.7.1, 2.7.2, 3.0.0, 3.0.3, 3.1.0, 3.1.1, 3.1.2
-     	Passenger: Version: ruby 3.1.1p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
-=> host-2.stanford.edu - App: 3.1.1, Default: 3.1.1, Installed: 2.7.1, 2.7.2, 3.0.0, 3.0.3, 3.1.0, 3.1.1, 3.1.2
-      Passenger: Version: ruby 3.1.1p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
-```
-
-The `check_app_version` task is a human readable format of the `installed_versions` task. If the application does not default a version in the `Gemfile` then `N/A` is reported.
-
-#### ruby:verify_deployed_version
-
-The `verify_deployed_version` is available to use as a deployment hook in order to halt deployment on a version mismatch
-
-By default, this task is disabled. Add the following to `configs/deploy.rb` to enable the `verify_deployed_version` task.
+This task may be used automatically at deploy time (after pulling the specified branch) by opting in. By default, this task does *not* run automatically. To enable that, add the following to `config/deploy.rb`:
 
 ```
 set :validate_ruby_on_deploy, true # Default value is false
 ```
 
-When enabled, the validation can be manually skipped when necessary by setting the `SKIP_VALIDATE_RUBY` environment veriable:
+Even after you opt in, the validation may be skipped on demand by setting the `SKIP_VALIDATE_RUBY` environment veriable:
 ```
 SKIP_VALIDATE_RUBY=true bundle exec cap env deploy
 ```
 
-If there is a version mismatch, the deployment will be stopped and the following message will be reported:
-```
-Cannot deploy because app requires ruby 3.1.1 and it is not installed (2.7.2, 2.7.5)
-```
-
-In the case that the application does not define a version in the `Gemfile` report will look like:
-```
-Ruby version not set in application, check Gemfile
-```
-
-If the version required by the app is not reported as the version being used by Passenger, the deployment will be aborted with the following message:
-```
-Cannot deploy because app required ruby 3.1.1, Passenger is configured to use:
-    Passenger: Version: ruby 3.0.3p157 (2021-11-24 revision 3fb7d2cadc) [x86_64-linux]
-```
 ## Assumptions
 
 dlss-capistrano makes the following assumptions about your Ruby project

--- a/README.md
+++ b/README.md
@@ -114,6 +114,45 @@ after 'deploy:starting', 'sidekiq_systemd:quiet'
 after 'deploy:updated', 'sidekiq_systemd:stop'
 ```
 
+
+### Verify Ruby Versions
+
+There are three tasks available to check and verify the ruby version(s) installed and being used on the remote server:
+
+#### versions
+
+```
+bundle exec cap env ruby:versions
+=> host-1.stanford.edu,3.1.1,2.7.1,2.7.2,3.0.0,3.0.3,3.1.0,3.1.1,3.1.2
+=> host-2.stanford.edu,3.1.1,2.7.1,2.7.2,3.0.0,3.0.3,3.1.0,3.1.1,3.1.2
+```
+
+This comma seperated list is hostname,default ruby,installed versions. This list can then be uesd in automated deployment tools to report across hosts where version mismatches may occur.
+
+#### check_version
+```
+bundle exec cap env ruby:check_version
+=> host-1.stanford.edu - App: 3.1.1, Default: 3.1.1, Installed: 2.7.1, 2.7.2, 3.0.0, 3.0.3, 3.1.0, 3.1.1, 3.1.2
+=> host-2.stanford.edu - App: 3.1.1, Default: 3.1.1, Installed: 2.7.1, 2.7.2, 3.0.0, 3.0.3, 3.1.0, 3.1.1, 3.1.2
+```
+
+The `check_version` task is a human readable format of the `versions` task.
+
+#### verify_version
+
+The `verify_version` is available to use as a deployment hook in order to halt deployment on a version mismatch
+
+Add the following to `configs/deploy/env.rb`
+
+```
+before 'deploy:starting', 'ruby:verify_version'
+```
+
+If there is a version mismatch, the deployment will be stopped and the following message will be reported:
+```
+Cannot deploy because app requires ruby 3.1.1 and it is not installed (2.7.2, 2.7.5)
+```
+
 ## Assumptions
 
 dlss-capistrano makes the following assumptions about your Ruby project

--- a/README.md
+++ b/README.md
@@ -119,38 +119,43 @@ after 'deploy:updated', 'sidekiq_systemd:stop'
 
 There are three tasks available to check and verify the ruby version(s) installed and being used on the remote server:
 
-#### versions
+#### ruby:installed_versions
 
 ```
 bundle exec cap env ruby:versions
-=> host-1.stanford.edu,3.1.1,2.7.1,2.7.2,3.0.0,3.0.3,3.1.0,3.1.1,3.1.2
-=> host-2.stanford.edu,3.1.1,2.7.1,2.7.2,3.0.0,3.0.3,3.1.0,3.1.1,3.1.2
+=> host-1.stanford.edu: 3.1.1,2.7.1,2.7.2,3.0.0,3.0.3,3.1.0,3.1.1,3.1.2
+=> host-2.stanford.edu: 3.1.1,2.7.1,2.7.2,3.0.0,3.0.3,3.1.0,3.1.1,3.1.2
 ```
 
-This comma seperated list is hostname,default ruby,installed versions. This list can then be uesd in automated deployment tools to report across hosts where version mismatches may occur.
+This comma seperated list is `hostname: default ruby,installed versions`. This list can then be uesd in automated deployment tools to report across hosts where version mismatches may occur.
 
-#### check_version
+#### ruby:check_app_version
 ```
 bundle exec cap env ruby:check_version
 => host-1.stanford.edu - App: 3.1.1, Default: 3.1.1, Installed: 2.7.1, 2.7.2, 3.0.0, 3.0.3, 3.1.0, 3.1.1, 3.1.2
 => host-2.stanford.edu - App: 3.1.1, Default: 3.1.1, Installed: 2.7.1, 2.7.2, 3.0.0, 3.0.3, 3.1.0, 3.1.1, 3.1.2
 ```
 
-The `check_version` task is a human readable format of the `versions` task.
+The `check_app_version` task is a human readable format of the `installed_versions` task. If the application does not default a version in the `Gemfile` then `N/A` is reported.
 
-#### verify_version
+#### ruby:verify_deployed_version
 
-The `verify_version` is available to use as a deployment hook in order to halt deployment on a version mismatch
+The `verify_deployed_version` is available to use as a deployment hook in order to halt deployment on a version mismatch
 
 Add the following to `configs/deploy/env.rb`
 
 ```
-before 'deploy:starting', 'ruby:verify_version'
+before 'deploy:starting', 'ruby:verify_deployed_version'
 ```
 
 If there is a version mismatch, the deployment will be stopped and the following message will be reported:
 ```
 Cannot deploy because app requires ruby 3.1.1 and it is not installed (2.7.2, 2.7.5)
+```
+
+In the case that the application does not define a version in the `Gemfile` report will look like:
+```
+Ruby version not set in application, check Gemfile
 ```
 
 ## Assumptions

--- a/dlss-capistrano.gemspec
+++ b/dlss-capistrano.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "capistrano", "~> 3.0"
   s.add_dependency "capistrano-bundle_audit", ">= 0.3.0"
   s.add_dependency "capistrano-one_time_key"
+  s.add_dependency "capistrano-rvm"
   s.add_dependency "capistrano-shared_configs"
 
   s.files         = `git ls-files`.split($/)

--- a/lib/dlss/capistrano.rb
+++ b/lib/dlss/capistrano.rb
@@ -1,5 +1,6 @@
 require 'capistrano/one_time_key'
 require 'capistrano/bundle_audit'
 require 'capistrano/shared_configs'
+require 'capistrano/rvm'
 
 Dir.glob("#{__dir__}/capistrano/tasks/*.rake").each { |r| import r }

--- a/lib/dlss/capistrano/tasks/check_ruby_version.rake
+++ b/lib/dlss/capistrano/tasks/check_ruby_version.rake
@@ -1,19 +1,19 @@
 # Note:
 # - The '/bin/bash -lc' syntax below is addressing https://github.com/sul-dlss/operations-tasks/issues/2937
 namespace :ruby do
-  desc 'Retrieve ruby versions'
-  task :versions do
+  desc 'Retrieve the installed versions of ruby'
+  task :installed_versions do
     on roles(:all), in: :sequence do |host|
       default_ruby = capture("/bin/bash -lc 'rvm list default string'").chomp.chomp.split('-').last
       system_rubies = capture("/bin/bash -lc 'rvm list rubies'").split.grep(/ruby/).map do |version|
         version.delete_prefix('ruby-')
       end
-      info "#{host},#{default_ruby},#{system_rubies.join(',')}"
+      info "#{host}: #{default_ruby},#{system_rubies.join(',')}"
     end
   end
 
   desc 'Report ruby versions'
-  task :check_version do
+  task :check_app_version do
     on roles(:all), in: :sequence do |host|
       app_ruby = 'N/A' || Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock')).ruby_version&.split.last.split('p').first
 
@@ -22,20 +22,20 @@ namespace :ruby do
         version.delete_prefix('ruby-')
       end
 
-      unless app_ruby.nil?
-        info "#{host} - App: #{app_ruby}, Default: #{default_ruby}, Installed: #{system_rubies.join(', ')}"
-      end
+      info "#{host} - App: #{app_ruby}, Default: #{default_ruby}, Installed: #{system_rubies.join(', ')}"
     end
   end
 
   desc 'Verify ruby version'
-  task :verify_version do
+  task :verify_deployed_version do
     on roles(:all), in: :sequence do |host|
-      app_ruby = Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock')).ruby_version.split.last.split('p').first
+      app_ruby = Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock')).ruby_version&.split&.last&.split('p')&.first
       default_ruby = capture("/bin/bash -lc 'rvm list default string'").chomp.chomp.split('-').last
       system_rubies = capture("/bin/bash -lc 'rvm list rubies'").split.grep(/ruby/).map do |version|
         version.delete_prefix('ruby-')
       end
+
+      abort 'Ruby version not set in application, check Gemfile' if app_ruby.nil?
 
       if system_rubies.include?(app_ruby)
         if app_ruby == default_ruby

--- a/lib/dlss/capistrano/tasks/check_ruby_version.rake
+++ b/lib/dlss/capistrano/tasks/check_ruby_version.rake
@@ -60,8 +60,8 @@ namespace :ruby do
 
       if app_ruby.nil?
         abort 'Ruby version not set in Gemfile.lock and capistrano configured to validate Ruby version, check Gemfile or run bundle install' if app_ruby.nil?
-      elsif !passenger_ruby.empty? && !passenger_ruby.include?(app_ruby)
-        abort "Cannot deploy because app required ruby #{app_ruby} and Passenger is using #{passenger_ruby}"
+      # elsif !passenger_ruby.empty? && !passenger_ruby.include?(app_ruby)
+      #   abort "Cannot deploy because app required ruby #{app_ruby} and Passenger is using #{passenger_ruby}"
       elsif !system_rubies.include?(app_ruby)
         abort "Cannot deploy because app requires ruby #{app_ruby} and it is not installed (#{system_rubies.join(', ')})"
       else

--- a/lib/dlss/capistrano/tasks/check_ruby_version.rake
+++ b/lib/dlss/capistrano/tasks/check_ruby_version.rake
@@ -1,82 +1,65 @@
 # Capistrano plugin hook to set default values
 namespace :load do
   task :defaults do
-    set :validate_ruby_on_deploy, fetch(:validate_ruby_on_deploy, false) # This is required to opt-in to the validation
-    set :skip_validate_ruby, !!ENV['SKIP_VALIDATE_RUBY']
+    # This is required to opt-in to the validation
+    set :validate_ruby_on_deploy, fetch(:validate_ruby_on_deploy, false)
   end
 end
 
-# Integrate sidekiq-bundle hook into Capistrano
+# Add ruby validation hook if app has opted in
 namespace :deploy do
-  before :starting, :add_validate_ruby_hook do
+  before :starting, :setup_validate_ruby_hook do
     invoke 'ruby:add_hook' if fetch(:validate_ruby_on_deploy)
   end
 end
 
-# Note:
-# - The '/bin/bash -lc' syntax below is addressing https://github.com/sul-dlss/operations-tasks/issues/2937
+# NOTE: the `/bin/bash -lc` syntax below addresses https://github.com/sul-dlss/operations-tasks/issues/2937
 namespace :ruby do
-  desc 'Retrieve the installed versions of ruby'
-  task :installed_versions do
-    on roles(:all), in: :sequence do |host|
-      default_ruby = capture("/bin/bash -lc 'rvm list default string'").chomp.chomp.split('-').last
-      system_rubies = capture("/bin/bash -lc 'rvm list rubies'").split.grep(/ruby/).map do |version|
-        version.delete_prefix('ruby-')
-      end
-      info "#{host}: #{default_ruby},#{system_rubies.join(',')}"
-    end
-  end
-
-  desc 'Report ruby versions'
-  task :check_app_version do
-    on roles(:all), in: :sequence do |host|
-      app_ruby = Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock')).ruby_version&.split.last.split('p').first || 'N/A'
-
-      default_ruby = capture("/bin/bash -lc 'rvm list default string'").chomp.chomp.split('-').last
-      passenger_ruby = capture("/bin/bash -lc 'passenger-config about ruby-command string | grep -i Version'",
-                               raise_on_non_zero_exit: false)
-      system_rubies = capture("/bin/bash -lc 'rvm list rubies'").split.grep(/ruby/).map do |version|
-        version.delete_prefix('ruby-')
-      end
-
-      info_str = "#{host} - App: #{app_ruby}, Default: #{default_ruby}, Installed: #{system_rubies.join(', ')}"
-      info_str += "\n\tPassenger: #{passenger_ruby}" unless passenger_ruby.empty?
-
-      info info_str
-    end
-  end
-
-  # This adds the verify_deployed_Version task, when configured, early in the deploymen to avoid
+  # This adds the validate_deployed_version task, when configured, early in the deployment to avoid
   # cloning/symlinking/etc if we do not want the deploy to continue.
   task :add_hook do
-    before 'git:wrapper', 'ruby:verify_deployed_version' unless ENV['SKIP_VALIDATE_RUBY']
+    after 'deploy:updating', 'ruby:validate_deployed_version' unless ENV['SKIP_VALIDATE_RUBY']
   end
 
-  desc 'Verify ruby version'
-  task :verify_deployed_version do
+  desc 'Validate ruby version'
+  task :validate_deployed_version do
     on roles(:all), in: :sequence do |host|
       app_ruby = Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock')).ruby_version&.split&.last&.split('p')&.first
-      passenger_ruby = capture("/bin/bash -lc 'passenger-config about ruby-command string | grep -i Version'",
-                               raise_on_non_zero_exit: false)
-      default_ruby = capture("/bin/bash -lc 'rvm list default string'").chomp.chomp.split('-').last
-      system_rubies = capture("/bin/bash -lc 'rvm list rubies'").split.grep(/ruby/).map do |version|
+
+      # Make sure capistrano-rvm uses the version of Ruby specified in the Gemfile.lock
+      fetch(:rvm_map_bins).each do |command|
+        # Remove the earlier rvm prefix (via capistrano-rvm hook)
+        SSHKit.config.command_map.prefix[command.to_sym].shift
+        # Patc in the rvm prefix corresponding to the version of Ruby specified in Gemfile.lock
+        SSHKit.config.command_map.prefix[command.to_sym].unshift("#{fetch(:rvm_path)}/bin/rvm #{app_ruby} do")
+      end
+
+      default_ruby = capture("/bin/bash -lc 'rvm --color=no list default string'").chomp.chomp.split('-').last
+      system_rubies = capture("/bin/bash -lc 'rvm --color=no list rubies'").split.grep(/ruby/).map do |version|
         version.delete_prefix('ruby-')
       end
+      passenger_ruby = if capture("/bin/bash -lc 'command -v passenger-config'", raise_on_non_zero_exit: false).empty?
+                         ''
+                       else
+                         capture("/bin/bash -lc 'passenger-config about ruby-command string | grep -i Version'")
+                           .match(/Version: ruby (.+?) /)
+                           .captures
+                           .first
+                       end
 
-      abort 'Ruby version not set in application, check Gemfile' if app_ruby.nil?
+      info_str = "#{host} - App: #{app_ruby}, Default: #{default_ruby}, Installed: #{system_rubies.join(', ')}"
+      info_str += ", Passenger: #{passenger_ruby}" unless passenger_ruby.empty?
 
-      unless passenger_ruby.empty? || passenger_ruby.include?(app_ruby)
-        abort "Cannot deploy because app required ruby #{app_ruby} Passenger is configured to use:\n\t#{passenger_ruby}"
-      end
+      info info_str
 
-      if system_rubies.include?(app_ruby)
-        if app_ruby == default_ruby
-          info "Ruby #{app_ruby} is default on #{host}."
-        else
-          abort "Cannot deploy because app requires ruby #{app_ruby} and it is not default (#{system_rubies.join(', ')})"
-        end
-      else
+      if app_ruby.nil?
+        abort 'Ruby version not set in Gemfile.lock and capistrano configured to validate Ruby version, check Gemfile or run bundle install' if app_ruby.nil?
+      elsif !passenger_ruby.empty? && !passenger_ruby.include?(app_ruby)
+        abort "Cannot deploy because app required ruby #{app_ruby} and Passenger is using #{passenger_ruby}"
+      elsif !system_rubies.include?(app_ruby)
         abort "Cannot deploy because app requires ruby #{app_ruby} and it is not installed (#{system_rubies.join(', ')})"
+      else
+        info "Ruby #{app_ruby} is installed on #{host}."
       end
     end
   end

--- a/lib/dlss/capistrano/tasks/check_ruby_version.rake
+++ b/lib/dlss/capistrano/tasks/check_ruby_version.rake
@@ -1,0 +1,39 @@
+namespace :ruby do
+  desc 'Retrieve ruby versions'
+  task :versions do
+    on roles(:all), in: :sequence do |host|
+      default_ruby = capture('rvm list default string').chomp.chomp.split('-').last
+      system_rubies = capture('rvm list rubies').split.grep(/ruby/).map { |version| version.delete_prefix('ruby-') }
+      info "#{host},#{default_ruby},#{system_rubies.join(',')}"
+    end
+  end
+
+  desc 'Report ruby versions'
+  task :check_version do
+    on roles(:all), in: :sequence do |host|
+      app_ruby = Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock')).ruby_version.split.last.split('p').first
+      default_ruby = capture('rvm list default string').chomp.chomp.split('-').last
+      system_rubies = capture('rvm list rubies').split.grep(/ruby/).map { |version| version.delete_prefix('ruby-') }
+      info "#{host} - App: #{app_ruby}, Default: #{default_ruby}, Installed: #{system_rubies.join(', ')}"
+    end
+  end
+
+  desc 'Verify ruby version'
+  task :verify_version do
+    on roles(:all), in: :sequence do |host|
+      app_ruby = Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock')).ruby_version.split.last.split('p').first
+      default_ruby = capture('rvm list default string').chomp.chomp.split('-').last
+      system_rubies = capture('rvm list rubies').split.grep(/ruby/).map { |version| version.delete_prefix('ruby-') }
+
+      if system_rubies.include?(app_ruby)
+        if app_ruby == default_ruby
+          info "Ruby #{app_ruby} is default on #{host}."
+        else
+          abort "Cannot deploy because app requires ruby #{app_ruby} and it is not default (#{system_rubies.join(', ')})"
+        end
+      else
+        abort "Cannot deploy because app requires ruby #{app_ruby} and it is not installed (#{system_rubies.join(', ')})"
+      end
+    end
+  end
+end

--- a/lib/dlss/capistrano/tasks/check_ruby_version.rake
+++ b/lib/dlss/capistrano/tasks/check_ruby_version.rake
@@ -18,11 +18,12 @@ namespace :ruby do
       app_ruby = 'N/A' || Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock')).ruby_version&.split.last.split('p').first
 
       default_ruby = capture("/bin/bash -lc 'rvm list default string'").chomp.chomp.split('-').last
+      passenger_ruby = capture("/bin/bash -lc 'passenger-config about ruby-command string | grep -i Version'")
       system_rubies = capture("/bin/bash -lc 'rvm list rubies'").split.grep(/ruby/).map do |version|
         version.delete_prefix('ruby-')
       end
 
-      info "#{host} - App: #{app_ruby}, Default: #{default_ruby}, Installed: #{system_rubies.join(', ')}"
+      info "#{host} - App: #{app_ruby}, Default: #{default_ruby}, Installed: #{system_rubies.join(', ')}\n\tPassenger: #{passenger_ruby}"
     end
   end
 
@@ -30,12 +31,17 @@ namespace :ruby do
   task :verify_deployed_version do
     on roles(:all), in: :sequence do |host|
       app_ruby = Bundler::LockfileParser.new(Bundler.read_file('Gemfile.lock')).ruby_version&.split&.last&.split('p')&.first
+      passenger_ruby = capture("/bin/bash -lc 'passenger-config about ruby-command string | grep -i Version'")
       default_ruby = capture("/bin/bash -lc 'rvm list default string'").chomp.chomp.split('-').last
       system_rubies = capture("/bin/bash -lc 'rvm list rubies'").split.grep(/ruby/).map do |version|
         version.delete_prefix('ruby-')
       end
 
       abort 'Ruby version not set in application, check Gemfile' if app_ruby.nil?
+
+      unless passenger_ruby.include?(app_ruby)
+        abort "Cannot deploy because app required ruby #{app_ruby} Passenger is configured to use:\n\t#{passenger_ruby}"
+      end
 
       if system_rubies.include?(app_ruby)
         if app_ruby == default_ruby


### PR DESCRIPTION
## Why was this change made?

Per discussion on the @sul-dlss/infrastructure-team , we require a tool to verify ruby versions during deployment. This adds a hook to be used in application deployment to stop deployment if the required version is not installed or default.

This also adds reporting tasks that can be used in `sdr-deploy` to get a broad picture of all ruby versions in use and installed across the SDR applications.

Note: This makes the assumption that the ruby version is available in `Gemfile.lock`

## How was this change tested?



## Which documentation and/or configurations were updated?



