### PR TITLE
Fix bug preventing check_status task from working

### DIFF
--- a/lib/dlss/capistrano/tasks/bundled_sidekiq.rake
+++ b/lib/dlss/capistrano/tasks/bundled_sidekiq.rake
@@ -21,7 +21,7 @@ namespace :bundled_sidekiq do
 
   # NOTE: no `desc` here to avoid publishing this task in the `cap -T` list
   task :symlink do
-    on roles fetch(:bundled_sidekiq_roles) do
+    on roles(fetch(:bundled_sidekiq_roles)) do
       within release_path do
         bundled_sidekiq_path = capture(:bundle, :info, '--path', :sidekiq)
         execute(:ln, '-sf', bundled_sidekiq_path, "#{shared_path}/bundled_sidekiq")

--- a/lib/dlss/capistrano/tasks/check_status.rake
+++ b/lib/dlss/capistrano/tasks/check_status.rake
@@ -8,7 +8,7 @@ end
 
 desc 'Run status checks'
 task :check_status do
-  on roles fetch(:check_status_roles), in: :sequence do |host|
+  on roles(fetch(:check_status_roles)), in: :sequence do |host|
     status_url = "https://#{host}#{fetch(:check_status_path)}"
 
     info "Checking status at #{status_url}"

--- a/lib/dlss/capistrano/tasks/sidekiq_systemd.rake
+++ b/lib/dlss/capistrano/tasks/sidekiq_systemd.rake
@@ -24,28 +24,28 @@ namespace :sidekiq_systemd do
 
   desc 'Stop workers from picking up new jobs'
   task :quiet do
-    on roles fetch(:sidekiq_systemd_role) do
+    on roles(fetch(:sidekiq_systemd_role)) do
       sudo :systemctl, 'reload', 'sidekiq-*', raise_on_non_zero_exit: false
     end
   end
 
   desc 'Stop running workers gracefully'
   task :stop do
-    on roles fetch(:sidekiq_systemd_role) do
+    on roles(fetch(:sidekiq_systemd_role)) do
       sudo :systemctl, 'stop', 'sidekiq-*'
     end
   end
 
   desc 'Start workers'
   task :start do
-    on roles fetch(:sidekiq_systemd_role) do
+    on roles(fetch(:sidekiq_systemd_role)) do
       sudo :systemctl, 'start', 'sidekiq-*', '--all'
     end
   end
 
   desc 'Restart workers'
   task :restart do
-    on roles fetch(:sidekiq_systemd_role) do
+    on roles(fetch(:sidekiq_systemd_role)) do
       sudo :systemctl, 'restart', 'sidekiq-*', raise_on_non_zero_exit: false
     end
   end

--- a/lib/dlss/capistrano/tasks/sneakers_systemd.rake
+++ b/lib/dlss/capistrano/tasks/sneakers_systemd.rake
@@ -23,21 +23,21 @@ namespace :sneakers_systemd do
 
   desc 'Stop running workers gracefully'
   task :stop do
-    on roles fetch(:sneakers_systemd_role) do
+    on roles(fetch(:sneakers_systemd_role)) do
       sudo :systemctl, 'stop', 'sneakers'
     end
   end
 
   desc 'Start workers'
   task :start do
-    on roles fetch(:sneakers_systemd_role) do
+    on roles(fetch(:sneakers_systemd_role)) do
       sudo :systemctl, 'start', 'sneakers'
     end
   end
 
   desc 'Restart workers'
   task :restart do
-    on roles fetch(:sneakers_systemd_role) do
+    on roles(fetch(:sneakers_systemd_role)) do
       sudo :systemctl, 'restart', 'sneakers', raise_on_non_zero_exit: false
     end
   end


### PR DESCRIPTION
## Why was this change made?

It turns out the `on roles fetch()...` pattern does not work correctly when running the task in sequence. Operator precedence. So consistently use parens with `roles` to set a pattern that works in both cases (in sequence and not).



## How was this change tested?

argo-qa
