### PR TITLE
Add two error cases to status checking

### DIFF
--- a/lib/dlss/capistrano/tasks/check_status.rake
+++ b/lib/dlss/capistrano/tasks/check_status.rake
@@ -14,8 +14,12 @@ task :check_status do
     info "Checking status at #{status_url}"
     status_body = capture("curl #{status_url}")
 
-    if status_body.match?(/FAILED/)
+    if status_body.nil?
+      error 'Endpoint could not be reached'
+    elsif status_body.match?(/FAILED/)
       error status_body.lines.grep(/FAILED/).join
+    elsif !status_body.match?(/PASSED/)
+      error status_body
     else
       info SSHKit::Color.new($stdout).colorize('All checks passed!', :green)
     end


### PR DESCRIPTION
## Why was this change made?

While troubleshooting a was-registrar-app outage earlier today, we discovered that the check_status task currently fails to account for two cases:

1. When Passenger renders the error page, which is the behavior we see when the server errors out due to e.g. missing default gem versions;
2. When Passenger is down

This commit adds both cases to the check_status task and flags them both as errors.

## How was this change tested?

Ran it against was-registrar-app stage (passing state) and qa (failing state)

## Which documentation and/or configurations were updated?

None
