### PR TITLE
Create a way to bypass update_global_strscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ set :check_status_roles, [:my_status_check_web_role]
 set :check_status_path, '/my/status/check/endpoint'
 ```
 
+### Update global strscan gem
+
+This insures the global version of strscan matches the version specified in the bundle.
+
+To skip this step provide `SKIP_UPDATE_STRSCAN=1`
+
 ### SSH
 
 `cap ENV ssh` establishes an SSH connection to the host running in `ENV` environment, and changes into the current deployment directory

--- a/lib/dlss/capistrano/tasks/strscan.rake
+++ b/lib/dlss/capistrano/tasks/strscan.rake
@@ -14,5 +14,5 @@ task :update_global_strscan do
 end
 
 if Rake::Task.task_defined? :'passenger:restart'
-  before :'passenger:restart', :update_global_strscan
+  before :'passenger:restart', :update_global_strscan unless ENV['SKIP_UPDATE_STRSCAN']
 end


### PR DESCRIPTION
## Why was this change made?

We can't deploy prescat to prod presently.  See #39 

## How was this change tested?



## Which documentation and/or configurations were updated?



