### PR TITLE
Verify strscan version is a legit version before trying to install it

### DIFF
--- a/lib/dlss/capistrano/tasks/strscan.rake
+++ b/lib/dlss/capistrano/tasks/strscan.rake
@@ -1,18 +1,22 @@
-desc "ssh to the current directory on the server"
+desc "update the strscan default gem"
 task :update_global_strscan do
   on roles(:app) do |host|
     strscan_version = within release_path do
       capture(:bundle, 'exec', 'ruby', '-e', '"puts Gem::Specification.find_by_name(\'strscan\').version"', ' || true')
     end
 
-    if strscan_version.empty?
-      warn 'strscan is not installed'
-    else
-      execute "gem install strscan --silent --no-document -v #{strscan_version}"
+    next warn 'strscan is not installed' if strscan_version.empty?
+
+    begin
+      Gem::Version.new(strscan_version)
+    rescue ArgumentError
+      next warn "skipping, could not install strscan due to an unrelated error: #{strscan_version}"
     end
+
+    execute "gem install strscan --silent --no-document -v #{strscan_version}"
   end
 end
 
-if Rake::Task.task_defined? :'passenger:restart'
+if Rake::Task.task_defined?(:'passenger:restart')
   before :'passenger:restart', :update_global_strscan unless ENV['SKIP_UPDATE_STRSCAN']
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #39

This commit patches the `update_global_strscan` task for situations where the command to get the current version of strscan returns a string that is more than a version, e.g., a giant RVM error blob. This situation should not happen often but the extra safeguard is easy to add, especially given how often we rebuild VMs, and should not break current behavior.

## How was this change tested?

Ran against prescat-qa and -stage boxes
