### PR TITLE
Add gems for ed25519 support

### DIFF
--- a/dlss-capistrano.gemspec
+++ b/dlss-capistrano.gemspec
@@ -22,6 +22,9 @@ Gem::Specification.new do |s|
   s.add_dependency "capistrano-bundle_audit", ">= 0.3.0"
   s.add_dependency "capistrano-one_time_key"
   s.add_dependency "capistrano-shared_configs"
+  # support for MacOS 14.4+ usage of ed25519 SSH keys
+  s.add_dependency "ed25519"
+  s.add_dependency "bcrypt_pbkdf"
 
   s.files         = `git ls-files`.split($/)
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
## Why was this change made?
Adding these gems allows MacOS 14.4+ users with ed25519 SSH keys to deploy apps using `dlss-capistrano` gem with: `bundle exec cap <env> deploy`.

## How was this change tested?
Deploy to QA of an app using the locally updated gem. 


## Which documentation and/or configurations were updated?



