### PR TITLE
remote_execute task: don't truncate remote output

### DIFF
--- a/lib/dlss/capistrano/tasks/deployed_branch.rake
+++ b/lib/dlss/capistrano/tasks/deployed_branch.rake
@@ -1,5 +1,10 @@
 desc 'display the deployed branch and commit'
 task :deployed_branch do
+  # see https://github.com/mattbrictson/airbrussh/tree/v1.5.2?tab=readme-ov-file#capistrano-34x
+  Airbrussh.configure do |config|
+    config.truncate = false
+  end
+
   on roles(:app) do |host|
     within current_path do
       revision = capture :cat, 'REVISION'

--- a/lib/dlss/capistrano/tasks/remote_execute.rake
+++ b/lib/dlss/capistrano/tasks/remote_execute.rake
@@ -2,6 +2,11 @@ desc "execute command on all servers"
 task :remote_execute, :command do |_task, args|
   raise ArgumentError, 'remote_execute task requires an argument' unless args[:command]
 
+  # see https://github.com/mattbrictson/airbrussh/tree/v1.5.2?tab=readme-ov-file#capistrano-34x
+  Airbrussh.configure do |config|
+    config.truncate = false
+  end
+
   on roles(:all) do |host|
     info args[:command] if fetch(:log_level) == :debug
     info "#{host}:\n#{capture(args[:command])}"


### PR DESCRIPTION
## Why was this change made?

it's useful to have the full output of these tasks.

## How was this change tested?

* pointed my local technical-metadata-service at my local copy of this dlss-capistrano branch, ran the changed commands, and ran `ssh_check` to make sure things still worked.
* did a test deploy (techMD to QA) just to make extra sure i didn't inadvertently break anything.
* i didn't see any specs in this repo, so i figured why start now 🙂


### `remote_execute`

#### before
```
 % git grep 'dlss-capistrano' Gemfile.lock; echo && echo; be cap qa 'remote_execute[tail -n1 dor_techmd/revisions.log && ruby -v]'
Gemfile.lock:    dlss-capistrano (4.4.1)
Gemfile.lock:  dlss-capistrano


Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
00:00 remote_execute
      dor-techmd-qa-a.stanford.edu:
Branch rel-2024-04-29 (at e5934482924397abab1f7c36b06a726fde584c35) deployed as release …
      dor-techmd-worker-qa-a.stanford.edu:
Branch rel-2024-04-29 (at e5934482924397abab1f7c36b06a726fde584c35) deployed as r…
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
```

#### after
```
% git grep 'dlss-capistrano' Gemfile.lock; echo && echo; be cap qa 'remote_execute[tail -n1 dor_techmd/revisions.log && ruby -v]'
Gemfile.lock:  remote: ../dlss-capistrano
Gemfile.lock:    dlss-capistrano (4.4.1)
Gemfile.lock:  dlss-capistrano!


Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
00:00 remote_execute
      dor-techmd-qa-a.stanford.edu:
Branch rel-2024-04-29 (at e5934482924397abab1f7c36b06a726fde584c35) deployed as release 20240429163604 by auser
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]
      dor-techmd-worker-qa-a.stanford.edu:
Branch rel-2024-04-29 (at e5934482924397abab1f7c36b06a726fde584c35) deployed as release 20240429163604 by auser
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [x86_64-linux]
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
```

### `deployed_branch`

#### before

```
% be cap qa deployed_branch                          iss515-audit-endpoint
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
warning: ignoring broken ref refs/remotes/origin/HEAD
00:00 deployed_branch
      dor-techmd-qa-a.stanford.edu: e5934482924397abab1f7c36b06a726fde584c35 (origin/iss515-audit-endpoint
  origin/main
  o…
warning: ignoring broken ref refs/remotes/origin/HEAD
      dor-techmd-worker-qa-a.stanford.edu: e5934482924397abab1f7c36b06a726fde584c35 (origin/iss515-audit-endpoint
  origin/m…
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
```

#### after

```
% be cap qa deployed_branch                          iss515-audit-endpoint
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
warning: ignoring broken ref refs/remotes/origin/HEAD
00:00 deployed_branch
      dor-techmd-qa-a.stanford.edu: e5934482924397abab1f7c36b06a726fde584c35 (origin/iss515-audit-endpoint
  origin/main
  origin/touchups)
warning: ignoring broken ref refs/remotes/origin/HEAD
      dor-techmd-worker-qa-a.stanford.edu: e5934482924397abab1f7c36b06a726fde584c35 (origin/iss515-audit-endpoint
  origin/main
  origin/touchups)
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
```
## Which documentation and/or configurations were updated?



