### PR TITLE
[HOLD] Automate setting up SSH multiplexing before running tasks

### DIFF
--- a/dlss-capistrano.gemspec
+++ b/dlss-capistrano.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   # the dependent gem's development-time.
   s.add_dependency "capistrano", "~> 3.0"
   s.add_dependency "capistrano-bundle_audit", ">= 0.3.0"
-  s.add_dependency "capistrano-one_time_key"
   s.add_dependency "capistrano-shared_configs"
+  s.add_dependency "net-ssh-krb"
   # support for MacOS 14.4+ usage of ed25519 SSH keys
   s.add_dependency "ed25519"
   s.add_dependency "bcrypt_pbkdf"

--- a/lib/dlss/capistrano.rb
+++ b/lib/dlss/capistrano.rb
@@ -1,5 +1,15 @@
-require 'capistrano/one_time_key'
 require 'capistrano/bundle_audit'
 require 'capistrano/shared_configs'
+require 'net/ssh/kerberos'
+
+# NOTE: This is only here so we can test this task against any host without needing to touch config/deploy/*.rb
+#
+# Instead of generating a one-time key, add legit gssapi authN via `net-ssh-krb` gem (thanks again, cbeer!)
+module Capistrano
+  module OneTimeKey
+    def self.generate_one_time_key!
+    end
+  end
+end
 
 Dir.glob("#{__dir__}/capistrano/tasks/*.rake").each { |r| import r }

--- a/lib/dlss/capistrano/tasks/control_master.rake
+++ b/lib/dlss/capistrano/tasks/control_master.rake
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+CONTROLMASTER_HOST = ENV.fetch('CONTROLMASTER_HOST', 'dlss-jump')
+CONTROLMASTER_SOCKET = ENV.fetch('CONTROLMASTER_SOCKET', "~/.ssh/%r@%h:%p")
+
+# Integrate hook into Capistrano
+namespace :deploy do
+  before :starting, :setup_controlmaster do
+    invoke 'controlmaster:setup'
+  end
+end
+
+namespace :controlmaster do
+  desc 'set up an SSH controlmaster process if missing'
+  task :setup do
+    if fetch(:log_level) == :debug
+      puts "checking if controlmaster process exists (#{CONTROLMASTER_SOCKET}) for #{CONTROLMASTER_HOST}"
+    end
+
+    status, output = Open3.popen2e(
+      "ssh -O check -S #{CONTROLMASTER_SOCKET} #{CONTROLMASTER_HOST}"
+    ) { |_, outerr, wait_thr| next wait_thr.value, outerr.read }
+
+    if status.success?
+      puts 'controlmaster process exists, nothing to do' if fetch(:log_level) == :debug
+      next
+    end
+
+    puts "controlmaster process missing (#{status}): #{output}"
+    invoke 'controlmaster:start'
+  end
+
+  # NOTE: no `desc` here to avoid publishing this task in the `cap -T` list
+  task :start do
+    if fetch(:log_level) == :debug
+      puts "creating new controlmaster process for #{CONTROLMASTER_HOST} at #{CONTROLMASTER_SOCKET}"
+    end
+
+    status, output = Open3.popen2e(
+      "ssh -f -N -S #{CONTROLMASTER_SOCKET} #{CONTROLMASTER_HOST}"
+    ) { |_, outerr, wait_thr| next wait_thr.value, outerr.read }
+
+    if status.success?
+      puts 'new controlmaster process created, moving on' if fetch(:log_level) == :debug
+      next
+    end
+
+    abort "could not create controlmaster process (#{status}): #{output}"
+  end
+end

--- a/lib/dlss/capistrano/tasks/deployed_branch.rake
+++ b/lib/dlss/capistrano/tasks/deployed_branch.rake
@@ -1,5 +1,5 @@
 desc 'display the deployed branch and commit'
-task :deployed_branch do
+task deployed_branch: 'controlmaster:setup' do
   # see https://github.com/mattbrictson/airbrussh/tree/v1.5.2?tab=readme-ov-file#capistrano-34x
   Airbrussh.configure do |config|
     config.truncate = false

--- a/lib/dlss/capistrano/tasks/remote_execute.rake
+++ b/lib/dlss/capistrano/tasks/remote_execute.rake
@@ -1,5 +1,16 @@
+# Capistrano plugin hook to set default values
+
+namespace :load do
+  task :defaults do
+    ssh_options = fetch(:ssh_options, {}).merge(
+      auth_methods: %w(gssapi-with-mic publickey hostbased password keyboard-interactive)
+    )
+    set :ssh_options, **ssh_options
+  end
+end
+
 desc "execute command on all servers"
-task :remote_execute, :command do |_task, args|
+task :remote_execute, [:command] => 'controlmaster:setup' do |_task, args|
   raise ArgumentError, 'remote_execute task requires an argument' unless args[:command]
 
   # see https://github.com/mattbrictson/airbrussh/tree/v1.5.2?tab=readme-ov-file#capistrano-34x

--- a/lib/dlss/capistrano/tasks/ssh.rake
+++ b/lib/dlss/capistrano/tasks/ssh.rake
@@ -1,5 +1,5 @@
 desc "ssh to the current directory on the server"
-task :ssh do
+task ssh: 'controlmaster:setup' do
   on roles(:app), :primary => true do |host|
     command = "cd #{fetch(:deploy_to)}/current && exec $SHELL -l"
     puts command if fetch(:log_level) == :debug

--- a/lib/dlss/capistrano/tasks/ssh_check.rake
+++ b/lib/dlss/capistrano/tasks/ssh_check.rake
@@ -1,5 +1,5 @@
 desc "check ssh connections to all app servers"
-task :ssh_check do
+task ssh_check: 'controlmaster:setup' do
   on roles(:app), in: :sequence do
     execute
   end


### PR DESCRIPTION
# Why was this change made?

This commit aims to make setting up SSH multiplexing easier by being a bit smarter about making SSH connections. Prior to this change, if you ran any of these tasks *before* manually setting up multiplexing, capistrano would happily make SSH connections to all the servers in the environment you asked to run the task in. This can lead to several-to-many concurrent SSH connections being made, each of which causes a Duo push. Any of the pushes you miss or cannot interact with due to the limitations of line-based terminals can cause authentication failures on servers, which add up and can lock you out due to repeated failed logins.

Instead, do the following:

* Use the `net-ssh-krb` gem to support the `gssapi-with-mic` SSH authentication method. This authentication will be used for connections made via the `remote_execute` task (HT: @cbeer)
* Monkey-patch `Capistrano::OneTimeKey` now that it is no longer needed. A problem with having `generate_one_time_key!` in every `config/deploy/*.rb` stage file is that this call makes an SSH connection before the Capistrano flow even begins, so this will happen *before* the multiplexing check happens, which means more connections and more confusion.
  * We can nix this monkey-patch if we remove the `Capistrano::OneTimeKey.generate_one_time_key!` call from all the `config/deploy/*.rb` files in all the repos that use `dlss-capistrano`. 😓 
* Add a new `controlmaster:setup` task that runs first in the Capistrano deployment flow. It checks for the presence of a controlmaster process (for SSH multiplexing), and if one does not exist, creates a new one.
* For tasks that are run outside of the deployment flow, add the `controlmaster:setup` task as a prerequisite
* Configure the `remote_execute` task to use the new `gssapi-with-mic` authentication method.

# How was this change tested?

Tested via:

1. Run deployed_branch without a controlmaster
2. Run deployed_branch with a controlmaster
3. Kill controlmaster
4. Run remote_execute without a controlmaster
5. Run remote_execute with a controlmaster
6. Kill controlmaster
7. Run ssh without a controlmaster
8. Run ssh with a controlmaster
9. Kill controlmaster
10. Run ssh_check without a controlmaster
11. Run ssh_check with a controlmaster
12. Kill controlmaster
13. Run deploy without a controlmaster
14. Run deploy with a controlmaster
15. Kill controlmaster

All steps do what I'd expect (prompt a single time for a task when no controlmaster is running, and do not prompt at all if one is running). I recommend testing with an app/env that has multiple servers, such as dor-services-app QA on the Infra side. Maybe there's a SearchWorks instance that can be tested on the Access side.
