### PR TITLE
[HOLD] do the same connection setup tasks before shared_configs tasks as before deploy flow starts

### DIFF
--- a/lib/dlss/capistrano/tasks/control_master.rake
+++ b/lib/dlss/capistrano/tasks/control_master.rake
@@ -17,6 +17,17 @@ namespace :deploy do
   end
 end
 
+namespace :shared_configs do
+  before :check, :setup_connection do
+    invoke 'controlmaster:setup'
+    invoke 'otk:generate'
+  end
+
+  before :update, :setup_connection
+  before :pull, :setup_connection
+  before :symlink, :setup_connection
+end
+
 namespace :controlmaster do
   desc 'set up an SSH controlmaster process if missing'
   task :setup do


### PR DESCRIPTION
## Why was this change made?

When I went to update shared_configs for sul-embed this afternoon to flip a feature flag change that'd already been merged, I got authN errors when running the `shared_configs:update` task.  Since what was deployed was sul-embed's most recent `main` commit, I was able to just re-deploy `main` to get to the same goal, but in many situations in many of our dlss-capistrano using apps, `main` would've drifted and wouldn't have been deployable as-is, making config updates in the absence of `shared_configs` cap tasks more of a pain.

## How was this change tested?

I pointed my local sul-embed to my local copy of this gem with these changes, and tested the following scenarios against stage:
* no current SSH control master -- i was prompted via duo, accepted the prompt, and logged in.
* an active SSH control master -- i was logged in without further prompting

## Which documentation and/or configurations were updated?

A `before` hook was used to trigger the same authN related tasks that are run before `deploy` tasks, but before running any of the tasks from the [current capistrano-shared_configs task list](https://github.com/sul-dlss/capistrano-shared_configs/blob/ba1aea95dbfeff36257b91a0f83749bcec439b7c/lib/capistrano/tasks/shared_configs.rake#L5-L46).